### PR TITLE
Removed Bootstrap + jQuery from webpack vendor config

### DIFF
--- a/webpack.config.vendor.js
+++ b/webpack.config.vendor.js
@@ -11,11 +11,8 @@ module.exports = (env) => {
         resolve: { extensions: [ '.js' ] },
         entry: {
             vendor: [
-                'bootstrap',
-                'bootstrap/dist/css/bootstrap.css',
                 'event-source-polyfill',
                 'isomorphic-fetch',
-                'jquery',
                 'vue',
                 'vue-router'
             ],


### PR DESCRIPTION
Webpack was failing to build the client side assets as it was still looking for the Bootstrap + jQuery dependencies in the webpack.config.vendor.js file.